### PR TITLE
move variable declaration to start of block - fixes vs2008 compile error

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -614,8 +614,8 @@ PyObject* _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject*
         }
 
         if (!multiple) {
-            Py_DECREF(self->lastrowid);
             sqlite_int64 lastrowid;
+            Py_DECREF(self->lastrowid);
             Py_BEGIN_ALLOW_THREADS
             lastrowid = sqlite3_last_insert_rowid(self->connection->db);
             Py_END_ALLOW_THREADS


### PR DESCRIPTION
VS2008 doesn't fully support the C99 standard. Therefore I had to move the declaration of a variable to the start of a code block in order to successfully compile on windows. 

The change is very minor and only occurred in one place. 