### PR TITLE
Add blob support

### DIFF
--- a/doc/includes/sqlite3/blob.py
+++ b/doc/includes/sqlite3/blob.py
@@ -1,0 +1,13 @@
+from pysqlite2 import dbapi2 as sqlite3
+con = sqlite3.connect(":memory:")
+# creating the table
+con.execute("create table test(id integer primary key, blob_col blob)")
+con.execute("insert into test(blob_col) values (zeroblob(10))")
+# opening blob handle
+blob = con.blob("test", "blob_col", 1, 1)
+blob.write("a" * 5)
+blob.write("b" * 5)
+blob.seek(0)
+print blob.read() # will print "aaaaabbbbb"
+blob.close()
+

--- a/doc/includes/sqlite3/blob_with.py
+++ b/doc/includes/sqlite3/blob_with.py
@@ -1,0 +1,12 @@
+from pysqlite2 import dbapi2 as sqlite3
+con = sqlite3.connect(":memory:")
+# creating the table
+con.execute("create table test(id integer primary key, blob_col blob)")
+con.execute("insert into test(blob_col) values (zeroblob(10))")
+# opening blob handle
+with con.blob("test", "blob_col", 1, 1) as blob:
+    blob.write("a" * 5)
+    blob.write("b" * 5)
+    blob.seek(0)
+    print blob.read() # will print "aaaaabbbbb" 
+

--- a/doc/sphinx/sqlite3.rst
+++ b/doc/sphinx/sqlite3.rst
@@ -241,6 +241,13 @@ Connection Objects
    :class:`sqlite3.Cursor`.
 
 
+.. method:: Connection.blob(table, column, row, flags=0, dbname="main")
+
+   On success a :class:`Blob` handle to the blob located in row 'row', 
+   column 'column', table 'table' in database 'dbname' will be returned.
+   The flags represent the blob mode. 0 for read-only otherwise read-write.
+
+
 .. method:: Connection.commit()
 
    This method commits the current transaction. If you don't call this method,
@@ -659,6 +666,60 @@ Now we plug :class:`Row` in::
     RHAT
     100.0
     35.14
+
+
+.. _sqlite3-blob-objects:
+
+Blob Objects
+--------------
+
+.. class:: Blob
+
+A :class:`Blob` instance has the following attributes and methods:
+
+   A SQLite database blob has the following attributes and methods:
+
+.. method:: Blob.close()
+
+   Close the blob now (rather than whenever __del__ is called).
+
+   The blob will be unusable from this point forward; an Error (or subclass)
+   exception will be raised if any operation is attempted with the blob.
+
+.. method:: Blob.length()
+
+   Return the blob size.
+
+.. method:: Blob.read([length])
+
+   Read lnegth bytes of data from the blob at the current offset position. If the
+   end of the blob is reached we will return the data up to end of file. When 
+   length is not specified or negative we will read up to end of blob.
+
+.. method:: Blob.write(data)
+
+   Write data to the blob at the current offset. This function cannot changed blob
+   length. If data write will result in writing to more then blob current size an 
+   error will be raised.
+
+.. method:: Blob.tell()
+
+   Return the current offset of the blob.
+
+.. method:: Blob.seek(offset, [whence])
+
+   Set the blob offset. The whence argument is optional and defaults to os.SEEK_SET 
+   or 0 (absolute blob positioning); other values are os.SEEK_CUR or 1 (seek 
+   relative to the current position) and os.SEEK_END or 2 (seek relative to the blob’s end).
+
+
+:class:`Blob` example:
+
+   .. literalinclude:: ../includes/sqlite3/blob.py
+
+A :class:`Blob` can also be used with context manager:
+
+   .. literalinclude:: ../includes/sqlite3/blob_with.py
 
 
 .. _sqlite3-types:

--- a/lib/test/dbapi.py
+++ b/lib/test/dbapi.py
@@ -475,6 +475,42 @@ class CursorTests(unittest.TestCase):
         except TypeError:
             pass
 
+
+class BlobTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(id integer primary key, blob_col blob)")
+        self.cx.execute("insert into test(blob_col) values (zeroblob(100))")
+        self.blob = self.cx.blob("test", "blob_col", 1)
+
+    def tearDown(self):
+        self.blob.close()
+        self.cx.close()
+
+    def CheckLength(self):
+        self.assertEqual(self.blob.length(), 100)
+
+    def CheckTell(self):
+        self.assertEqual(self.blob.tell(), 0)
+
+    def CheckSeekFromBlobStart(self):
+        self.blob.seek(10)
+        self.assertEqual(self.blob.tell(), 10)
+        self.blob.seek(10, 0)
+        self.assertEqual(self.blob.tell(), 10)
+
+    def CheckSeekFromCurrentPosition(self):
+        self.blob.seek(10,1)
+        self.blob.seek(10,1)
+        self.assertEqual(self.blob.tell(), 20)
+
+    def CheckSeekFromBlobEnd(self):
+        self.blob.seek(-10,2)
+        self.assertEqual(self.blob.tell(), 90)
+
+
+
+
 @unittest.skipUnless(threading, 'This test requires threading.')
 class ThreadTests(unittest.TestCase):
     def setUp(self):
@@ -917,13 +953,14 @@ def suite():
     module_suite = unittest.makeSuite(ModuleTests, "Check")
     connection_suite = unittest.makeSuite(ConnectionTests, "Check")
     cursor_suite = unittest.makeSuite(CursorTests, "Check")
+    blob_suite = unittest.makeSuite(BlobTests, "Check")
     thread_suite = unittest.makeSuite(ThreadTests, "Check")
     constructor_suite = unittest.makeSuite(ConstructorTests, "Check")
     ext_suite = unittest.makeSuite(ExtensionTests, "Check")
     closed_con_suite = unittest.makeSuite(ClosedConTests, "Check")
     closed_cur_suite = unittest.makeSuite(ClosedCurTests, "Check")
     context_suite = unittest.makeSuite(ContextTests, "Check")
-    return unittest.TestSuite((module_suite, connection_suite, cursor_suite, thread_suite, constructor_suite, ext_suite, closed_con_suite, closed_cur_suite, context_suite))
+    return unittest.TestSuite((module_suite, connection_suite, cursor_suite, blob_suite, thread_suite, constructor_suite, ext_suite, closed_con_suite, closed_cur_suite, context_suite))
 
 def test():
     runner = unittest.TextTestRunner()

--- a/lib/test/dbapi.py
+++ b/lib/test/dbapi.py
@@ -587,6 +587,42 @@ class BlobTests(unittest.TestCase):
         except Exception:
             self.fail("should have raised a sqlite.OperationalError")
 
+    def CheckBlobOpenWithBadDb(self):
+        try:
+            self.cx.blob("test", "blob_col", 1, 1, dbname="notexisintg")
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobOpenWithBadTable(self):
+        try:
+            self.cx.blob("notexisintg", "blob_col", 1, 1)
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobOpenWithBadColumn(self):
+        try:
+            self.cx.blob("test", "notexisting", 1, 1)
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobOpenWithBadRow(self):
+        try:
+            self.cx.blob("test", "blob_col", 2, 1)
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
 
 @unittest.skipUnless(threading, 'This test requires threading.')
 class ThreadTests(unittest.TestCase):

--- a/lib/test/dbapi.py
+++ b/lib/test/dbapi.py
@@ -887,6 +887,20 @@ class ClosedConTests(unittest.TestCase):
         except:
             self.fail("Should have raised a ProgrammingError")
 
+    def CheckClosedBlobRead(self):
+        con = sqlite.connect(":memory:")
+        con.execute("create table test(id integer primary key, blob_col blob)")
+        con.execute("insert into test(blob_col) values (zeroblob(100))")
+        blob = con.blob("test", "blob_col", 1)
+        con.close()
+        try:
+            blob.read()
+            self.fail("Should have raised a ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+        except:
+            self.fail("Should have raised a ProgrammingError")
+
     def CheckClosedCreateFunction(self):
         con = sqlite.connect(":memory:")
         con.close()

--- a/lib/test/dbapi.py
+++ b/lib/test/dbapi.py
@@ -554,9 +554,38 @@ class BlobTests(unittest.TestCase):
         self.assertEqual(str(self.cx.execute("select blob_col from test").fetchone()[0]),
                          self.blob_data[:50] + self.second_data[:50])
 
-    def CheckBlobWriteMoveOffset(self):
+    def CheckBlobWriteAdvanceOffset(self):
         self.blob.write(self.second_data[:50])
         self.assertEqual(self.blob.tell(), 50)
+
+    def CheckBlobWriteMoreThenBlobSize(self):
+        try:
+            self.blob.write("a" * 1000)
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobReadAfterRowChange(self):
+        self.cx.execute("UPDATE test SET blob_col='aaaa' where id=1")
+        try:
+            self.blob.read()
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobWriteAfterRowChange(self):
+        self.cx.execute("UPDATE test SET blob_col='aaaa' where id=1")
+        try:
+            self.blob.write("aaa")
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
 
 
 @unittest.skipUnless(threading, 'This test requires threading.')

--- a/lib/test/dbapi.py
+++ b/lib/test/dbapi.py
@@ -481,7 +481,7 @@ class BlobTests(unittest.TestCase):
         self.cx = sqlite.connect(":memory:")
         self.cx.execute("create table test(id integer primary key, blob_col blob)")
         self.cx.execute("insert into test(blob_col) values (zeroblob(100))")
-        self.blob = self.cx.blob("test", "blob_col", 1)
+        self.blob = self.cx.blob("test", "blob_col", 1, 1)
 
     def tearDown(self):
         self.blob.close()
@@ -508,8 +508,28 @@ class BlobTests(unittest.TestCase):
         self.blob.seek(-10,2)
         self.assertEqual(self.blob.tell(), 90)
 
+    def CheckBlobSeekOverBlobSize(self):
+        try:
+            self.blob.seek(1000)
+            self.fail("should have raised a ValueError")
+        except ValueError:
+            pass
+        except Exception:
+            self.fail("should have raised a ValueError")
 
+    def CheckBlobSeekUnderBlobSize(self):
+        try:
+            self.blob.seek(-10)
+            self.fail("should have raised a ValueError")
+        except ValueError:
+            pass
+        except Exception:
+            self.fail("should have raised a ValueError")
 
+    def CheckBlobWrite(self):
+        data = "a"*100
+        self.blob.write(data)
+        self.assertEqual(str(self.cx.execute("select blob_col from test").fetchone()[0]), data)
 
 @unittest.skipUnless(threading, 'This test requires threading.')
 class ThreadTests(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ PYSQLITE_EXPERIMENTAL = False
 
 sources = ["src/module.c", "src/connection.c", "src/cursor.c", "src/cache.c",
            "src/microprotocols.c", "src/prepare_protocol.c", "src/statement.c",
-           "src/util.c", "src/row.c"]
+           "src/util.c", "src/row.c", "src/blob.c"]
 
 if PYSQLITE_EXPERIMENTAL:
     sources.append("src/backup.c")

--- a/src/blob.c
+++ b/src/blob.c
@@ -7,16 +7,11 @@ int pysqlite_blob_init(pysqlite_Blob *self, pysqlite_Connection* connection, sql
     Py_INCREF(connection);
     self->connection = connection;
     self->offset=0;
-    self->in_weakreflist = NULL;
     self->blob = blob;
 
     if (!pysqlite_check_thread(self->connection)){
         return -1;
     }
-    // TODO: register blob
-    //if (!pysqlite_connection_register_cursor(connection, (PyObject*)self)) {
-    //    return -1;
-    //}
     return 0;
 }
 
@@ -31,11 +26,6 @@ static void pysqlite_blob_dealloc(pysqlite_Blob* self)
     }
 
     self->blob = NULL;
-
-    if (self->in_weakreflist != NULL) {
-        PyObject_ClearWeakRefs((PyObject*)self);
-    }
-    //TODO: remove from connection blob list
 
     self->ob_type->tp_free((PyObject*)self);
 }

--- a/src/blob.c
+++ b/src/blob.c
@@ -123,7 +123,12 @@ PyObject* pysqlite_blob_read(pysqlite_Blob *self, PyObject *args){
 
     if (rc != SQLITE_OK){
         Py_DECREF(buffer);
-        _pysqlite_seterror(self->connection->db, NULL);
+        // For some reasone after modifieng blob the error is not set on the connection db.
+        if (rc == SQLITE_ABORT){
+            PyErr_SetString(pysqlite_OperationalError, "Cannot operate on modified blob");
+        } else {
+            _pysqlite_seterror(self->connection->db, NULL);
+        }
         return NULL;
     }
 
@@ -153,7 +158,12 @@ PyObject* pysqlite_blob_write(pysqlite_Blob *self, PyObject *data){
     rc = sqlite3_blob_write(self->blob, data_buffer, data_size, self->offset);
     Py_END_ALLOW_THREADS
     if (rc != SQLITE_OK) {
-        _pysqlite_seterror(self->connection->db, NULL);
+        // For some reasone after modifieng blob the error is not set on the connection db.
+        if (rc == SQLITE_ABORT){
+            PyErr_SetString(pysqlite_OperationalError, "Cannot operate on modified blob");
+        } else {
+            _pysqlite_seterror(self->connection->db, NULL);
+        }
         return NULL;
     }
 

--- a/src/blob.c
+++ b/src/blob.c
@@ -1,0 +1,98 @@
+#include "blob.h"
+
+
+int pysqlite_blob_init(pysqlite_Blob *self, pysqlite_Connection* connection, sqlite3_blob *blob)
+{
+    Py_INCREF(connection);
+    self->connection = connection;
+    self->offset=0;
+    self->in_weakreflist = NULL;
+    self->blob = blob;
+
+    // TODO: register blob
+    //if (!pysqlite_connection_register_cursor(connection, (PyObject*)self)) {
+    //    return -1;
+    //}
+    return 0;
+}
+
+
+static void pysqlite_blob_dealloc(pysqlite_Blob* self)
+{
+    /* close the blob */
+    if (self->blob) {
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_blob_close(self->blob);
+        Py_END_ALLOW_THREADS
+    }
+
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }
+
+    self->ob_type->tp_free((PyObject*)self);
+}
+
+
+PyObject* pysqlite_blob_test(pysqlite_Blob *self, PyObject* args){
+    printf("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n");
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+
+static PyMethodDef blob_methods[] = {
+    {"test", (PyCFunction)pysqlite_blob_test, METH_NOARGS,
+        PyDoc_STR("test")},
+    {NULL, NULL}
+};
+
+
+PyTypeObject pysqlite_BlobType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".Blob",                            /* tp_name */
+        sizeof(pysqlite_Blob),                          /* tp_basicsize */
+        0,                                              /* tp_itemsize */
+        (destructor)pysqlite_blob_dealloc,              /* tp_dealloc */
+        0,                                              /* tp_print */
+        0,                                              /* tp_getattr */
+        0,                                              /* tp_setattr */
+        0,                                              /* tp_compare */
+        0,                                              /* tp_repr */
+        0,                                              /* tp_as_number */
+        0,                                              /* tp_as_sequence */
+        0,                                              /* tp_as_mapping */
+        0,                                              /* tp_hash */
+        0,                                              /* tp_call */
+        0,                                              /* tp_str */
+        0,                                              /* tp_getattro */
+        0,                                              /* tp_setattro */
+        0,                                              /* tp_as_buffer */
+        Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_WEAKREFS,    /* tp_flags */
+        0,                                              /* tp_doc */
+        0,                                              /* tp_traverse */
+        0,                                              /* tp_clear */
+        0,                                              /* tp_richcompare */
+        offsetof(pysqlite_Blob, in_weakreflist),        /* tp_weaklistoffset */
+        0,                                              /* tp_iter */
+        0,                                              /* tp_iternext */
+        blob_methods,                                   /* tp_methods */
+        0,                                              /* tp_members */
+        0,                                              /* tp_getset */
+        0,                                              /* tp_base */
+        0,                                              /* tp_dict */
+        0,                                              /* tp_descr_get */
+        0,                                              /* tp_descr_set */
+        0,                                              /* tp_dictoffset */
+        (initproc)pysqlite_blob_init,                   /* tp_init */
+        0,                                              /* tp_alloc */
+        0,                                              /* tp_new */
+        0                                               /* tp_free */
+};
+
+extern int pysqlite_blob_setup_types(void)
+{
+    pysqlite_BlobType.tp_new = PyType_GenericNew;
+    return PyType_Ready(&pysqlite_BlobType);
+}
+

--- a/src/blob.c
+++ b/src/blob.c
@@ -276,12 +276,12 @@ PyTypeObject pysqlite_BlobType = {
         0,                                              /* tp_getattro */
         0,                                              /* tp_setattro */
         0,                                              /* tp_as_buffer */
-        Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_WEAKREFS,    /* tp_flags */
+        Py_TPFLAGS_DEFAULT,                             /* tp_flags */
         0,                                              /* tp_doc */
         0,                                              /* tp_traverse */
         0,                                              /* tp_clear */
         0,                                              /* tp_richcompare */
-        offsetof(pysqlite_Blob, in_weakreflist),        /* tp_weaklistoffset */
+        0,                                              /* tp_weaklistoffset */
         0,                                              /* tp_iter */
         0,                                              /* tp_iternext */
         blob_methods,                                   /* tp_methods */

--- a/src/blob.h
+++ b/src/blob.h
@@ -1,0 +1,22 @@
+#ifndef PYSQLITE_BLOB_H
+#define PYSQLITE_BLOB_H
+#include "Python.h"
+#include "sqlite3.h"
+#include "connection.h"
+
+typedef struct
+{
+    PyObject_HEAD
+    pysqlite_Connection* connection;
+    sqlite3_blob *blob;
+    unsigned int offset;
+    PyObject* in_weakreflist; /* List of weak references */
+} pysqlite_Blob;
+
+extern PyTypeObject pysqlite_BlobType;
+
+int pysqlite_blob_init(pysqlite_Blob* self, pysqlite_Connection* connection, sqlite3_blob *blob);
+
+int pysqlite_blob_setup_types(void);
+
+#endif

--- a/src/blob.h
+++ b/src/blob.h
@@ -10,7 +10,6 @@ typedef struct
     pysqlite_Connection* connection;
     sqlite3_blob *blob;
     unsigned int offset;
-    PyObject* in_weakreflist; /* List of weak references */
 } pysqlite_Blob;
 
 extern PyTypeObject pysqlite_BlobType;

--- a/src/blob.h
+++ b/src/blob.h
@@ -10,11 +10,14 @@ typedef struct
     pysqlite_Connection* connection;
     sqlite3_blob *blob;
     unsigned int offset;
+
+    PyObject* in_weakreflist; /* List of weak references */
 } pysqlite_Blob;
 
 extern PyTypeObject pysqlite_BlobType;
 
 int pysqlite_blob_init(pysqlite_Blob* self, pysqlite_Connection* connection, sqlite3_blob *blob);
+PyObject* pysqlite_blob_close(pysqlite_Blob *self);
 
 int pysqlite_blob_setup_types(void);
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -324,17 +324,17 @@ PyObject* pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, 
 
 PyObject* pysqlite_connection_blob(pysqlite_Connection* self, PyObject* args, PyObject* kwargs)
 {
-    static char *kwlist[] = {"dbname", "table", "column", "row", "flags", NULL, NULL};
+    static char *kwlist[] = {"table", "column", "row", "flags", "dbname", NULL, NULL};
     int rc;
-    const char *dbname, *table, *column;
+    const char *dbname = "main", *table, *column;
     sqlite3_int64 row;
     int flags = 0;
     sqlite3_blob* blob;
     pysqlite_Blob *pyblob=0;
 
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sssL|i", kwlist,
-                                     &dbname, &table, &column, &row, &flags)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ssL|is", kwlist,
+                                     &table, &column, &row, &flags, &dbname)) {
         return NULL;
     }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -66,9 +66,10 @@ typedef struct
 
     pysqlite_Cache* statement_cache;
 
-    /* Lists of weak references to statements and cursors used within this connection */
+    /* Lists of weak references to statements, blobs and cursors used within this connection */
     PyObject* statements;
     PyObject* cursors;
+    PyObject* blobs;
 
     /* Counters for how many statements/cursors were created in the connection. May be
      * reset to 0 at certain intervals */

--- a/src/module.c
+++ b/src/module.c
@@ -28,6 +28,7 @@
 #include "prepare_protocol.h"
 #include "microprotocols.h"
 #include "row.h"
+#include "blob.h"
 
 #define DEPRECATE_ADAPTERS_MSG "Converters and adapters are deprecated. Please use only supported SQLite types. Any type mapping should happen in layer above this module."
 
@@ -296,6 +297,7 @@ PyMODINIT_FUNC init_sqlite(void)
         #ifdef PYSQLITE_EXPERIMENTAL
         (pysqlite_backup_setup_types() < 0) ||
         #endif
+        (pysqlite_blob_setup_types() < 0) ||
         (pysqlite_prepare_protocol_setup_types() < 0)
        ) {
         return;


### PR DESCRIPTION
This branch implements I/O access to blobs as asked in the bug:
http://bugs.python.org/issue24905

The blob API is like a python file API, thus implementing the read,write, seek, tell, close, **enter** and **exit**. The blob object can be opened from a connection using the blob method .
