### PR TITLE
Cursors as context managers

### DIFF
--- a/doc/sphinx/sqlite3.rst
+++ b/doc/sphinx/sqlite3.rst
@@ -484,6 +484,14 @@ A :class:`Cursor` instance has the following attributes and methods:
    The cursor will be unusable from this point forward; an Error (or subclass)
    exception will be raised if any operation is attempted with the cursor.
 
+   Note that an open cursor keeps a read lock on the database
+   (https://www.sqlite.org/opcode.html).  If you are using the same database
+   from multiple threads or processes, with some of those attempting to write
+   to the database, it is important to close open cursors as soon as possible
+   to allow write access.
+
+   See also :meth:`__enter__` below.
+   
 .. method:: Cursor.execute(sql, [parameters])
 
    Executes an SQL statement. The SQL statement may be parametrized (i. e.
@@ -594,6 +602,17 @@ A :class:`Cursor` instance has the following attributes and methods:
 
    It is set for ``SELECT`` statements without any matching rows as well.
 
+.. method:: Cursor.__enter__()
+	    
+   Non-standard method. Implements the context manager interface so a cursor
+   can be used in a ``with`` - statement. Exiting a cursor context will close
+   the cursor.
+
+.. method:: Cursor.__exit__()
+
+   See :meth:`__enter__` above.
+
+   
 .. _sqlite3-row-objects:
 
 Row Objects

--- a/lib/test/dbapi.py
+++ b/lib/test/dbapi.py
@@ -475,6 +475,18 @@ class CursorTests(unittest.TestCase):
         except TypeError:
             pass
 
+    def CheckCursorAsContext(self):
+        with self.cx.cursor() as cu:
+            cu.execute("select name from test")
+        try:
+            # this should fail as the cursor is closed already
+            # due to the context-manager with statement
+            cu.execute("select name from test")
+        except sqlite.ProgrammingError:
+            return
+        self.fail("expected a ProgrammingError")
+
+        
 @unittest.skipUnless(threading, 'This test requires threading.')
 class ThreadTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Hi,

I think it would be great if cursors could be used as context managers as well. They acquire a limiting resource: Read locks on the database file. In a multi-threaded or multi-process situation, it is important to not rely on (unreliable) garbage collection to mop up any old, open, unused cursors. In such a case, it is easy to end up with 'OperationalError: database is locked' errors on any process attempting to write.

This adds code to use cursors as context managers, like there is already for connections. Included is a simple test case (passes fine on python 2.7.6) and documentation of these methods.

But as a further suggestion, the docs might become more helpful if they would state this problem more clearly. Currently, the code examples do not deal with this problem and implicitly suggest the assumption that Python's garbage collection is sufficient and so implicitly assume a read-only or a single-threaded use-case of pysqlite.
