### PR TITLE
Change to try setuptools first, falling back to distutils.core.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,10 @@ import os
 import re
 import shutil
 
-from distutils.core import setup, Extension, Command
+try:
+    from setuptools import setup, Extension, Command
+except ImportError:
+    from distutils.core import setup, Extension, Command
 from distutils.command.build import build
 from distutils.command.build_ext import build_ext
 


### PR DESCRIPTION
* This allows for setuptools to be updated to a later version so on Windows, vcvarsall.bat can be located when using Microsoft Visual C++ Compiler for Python 2.7