### PR TITLE
Desambiguation of versions : pysqlite, python stdlib sqlite3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 pysqlite
 ========
 
-Python DB-API module for SQLite 3.
+pysqlite is a Python DB-API module for SQLite 3.
 
-Online documentation can be found [here] (https://pysqlite.readthedocs.org/en/latest/sqlite3.html).
+It is available for Python 2.x.
 
-You can get help from the community on the Google Group: https://groups.google.com/forum/#!forum/python-sqlite
+Online documentation can be found [here](https://pysqlite.readthedocs.org/en/latest/sqlite3.html).
+
+You can get help from the community on the Google Group [python-sqlite](https://groups.google.com/forum/#!forum/).
+
+Note: Python's standard-library built-in [`sqlite3` module](https://github.com/python/cpython/tree/master/Modules/_sqlite) is based on `pysqlite` (this project). However, they are maintained separately and they have slightly different APIs.
+
+Maintainer: [Gerhard Häring](https://github.com/ghaering)
+Maintainer of Python's standard-library `sqlite3` module: [Berker Peksag](https://github.com/berkerpeksag)

--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ You can get help from the community on the Google Group [python-sqlite](https://
 Note: Python's standard-library built-in [`sqlite3` module](https://github.com/python/cpython/tree/master/Modules/_sqlite) is based on `pysqlite` (this project). However, they are maintained separately and they have slightly different APIs.
 
 Maintainer: [Gerhard Häring](https://github.com/ghaering)
+
 Maintainer of Python's standard-library `sqlite3` module: [Berker Peksag](https://github.com/berkerpeksag)


### PR DESCRIPTION
I think this is useful because the similar names creates some confusion. (Also, I spoke with many developers, including on IRC, and most people didn't know if this project here is the Python stdlib one or not, etc.)